### PR TITLE
Expose HiDeF numthreads para

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,11 @@ The Cell Maps Generate Hierarchy is part of the Cell Mapping Toolkit
         :target: https://cellmaps-generate-hierarchy.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.17298670.svg
+        :target: https://zenodo.org/doi/10.5281/zenodo.17298670
+        :alt: Zenodo DOI badge
+
+
 Generates hierarchy from `Cell Maps Coembedding <https://cellmaps-coembedding.readthedocs.io/>`__ using `HiDeF <https://github.com/fanzheng10/HiDeF/>`__
 
 * Free software: MIT license

--- a/cellmaps_generate_hierarchy/cellmaps_generate_hierarchycmd.py
+++ b/cellmaps_generate_hierarchy/cellmaps_generate_hierarchycmd.py
@@ -77,6 +77,8 @@ def _parse_arguments(desc, args):
                         help='HiDeF clustering algorithm parameter')
     parser.add_argument('--maxres', default=CellmapsGenerateHierarchy.MAXRES, type=float,
                         help='HiDeF max resolution parameter')
+    parser.add_argument('--numthreads', default=CellmapsGenerateHierarchy.NUMTHREADS, type=int,
+                        help='HiDeF numthreads parameter')
     parser.add_argument('--containment_threshold', default=HiDeFHierarchyRefiner.CONTAINMENT_THRESHOLD, type=float,
                         help='Containment index threshold for pruning hierarchy')
     parser.add_argument('--jaccard_threshold', default=HiDeFHierarchyRefiner.JACCARD_THRESHOLD, type=float,
@@ -244,6 +246,7 @@ def main(args):
                                          algorithm=theargs.algorithm,
                                          maxres=theargs.maxres,
                                          k=theargs.k,
+                                         numthreads=theargs.numthreads,
                                          gene_node_attributes=theargs.gene_node_attributes,
                                          hiergen=hiergen,
                                          name=theargs.name,

--- a/cellmaps_generate_hierarchy/hierarchy.py
+++ b/cellmaps_generate_hierarchy/hierarchy.py
@@ -43,7 +43,7 @@ class HierarchyGenerator(object):
         """
         return self._generated_dataset_ids
 
-    def get_hierarchy(self, networks, algorithm='leiden', maxres=80, k=10):
+    def get_hierarchy(self, networks, algorithm='leiden', maxres=80, k=10, numthreads=8):
         """
         Gets hierarchy
 
@@ -562,11 +562,11 @@ class CDAPSHiDeFHierarchyGenerator(HierarchyGenerator):
                                        values='true', type='boolean',
                                        overwrite=True)
 
-    def _run_hidef(self, edgelist_files, outputprefix, algorithm, maxres, k):
+    def _run_hidef(self, edgelist_files, outputprefix, algorithm, maxres, k, numthreads):
         cmd = [self._python, self._hidef_cmd, '--g']
         cmd.extend(edgelist_files)
         cmd.extend(['--o', outputprefix,
-                    '--alg', algorithm, '--maxres', str(maxres), '--k', str(k),
+                    '--alg', algorithm, '--maxres', str(maxres), '--k', str(k), '--numthreads', str(numthreads),
                     '--skipgml'])
 
         exit_code, out, err = self._run_cmd(cmd)
@@ -577,7 +577,7 @@ class CDAPSHiDeFHierarchyGenerator(HierarchyGenerator):
             raise CellmapsGenerateHierarchyError('Cmd failed with exit code: ' + str(exit_code) +
                                                  ' : ' + str(out) + ' : ' + str(err))
 
-    def get_hierarchy_from_edgelists(self, outdir, edgelist_files, parent_net, algorithm='leiden', maxres=80, k=10):
+    def get_hierarchy_from_edgelists(self, outdir, edgelist_files, parent_net, algorithm='leiden', maxres=80, k=10, numthreads=8):
         """
         Generates a hierarchy from edgelist files using HiDeF.
 
@@ -597,12 +597,14 @@ class CDAPSHiDeFHierarchyGenerator(HierarchyGenerator):
         :type maxres: int
         :param k: The k parameter for HiDeF (default is 10).
         :type k: int
+        :param numthreads: The number of threads to run HiDeF (default is 8).
+        :type numthreads: int
         :return: A tuple containing the resulting hierarchy and the path to the CDAPS output JSON file, or (None, None) if an error occurs.
         :rtype: tuple (hierarchy, str) or (None, None)
         :raises FileNotFoundError: If no output is generated from HiDeF.
         """
         outputprefix = os.path.join(outdir, CDAPSHiDeFHierarchyGenerator.HIDEF_OUT_PREFIX)
-        self._run_hidef(edgelist_files, outputprefix, algorithm, maxres, k)
+        self._run_hidef(edgelist_files, outputprefix, algorithm, maxres, k, numthreads)
 
         try:
             if self._refiner is not None:
@@ -620,7 +622,7 @@ class CDAPSHiDeFHierarchyGenerator(HierarchyGenerator):
             logger.error('No output from hidef: ' + str(fe) + '\n')
         return None, None
 
-    def get_hierarchy(self, networks, algorithm='leiden', maxres=80, k=10):
+    def get_hierarchy(self, networks, algorithm='leiden', maxres=80, k=10, numthreads=8):
         """
         Runs HiDeF to generate hierarchy and registers resulting output
         files with FAIRSCAPE. To do this the method generates edgelist
@@ -647,6 +649,8 @@ class CDAPSHiDeFHierarchyGenerator(HierarchyGenerator):
         :type maxres: int
         :param k: The k parameter for HiDeF (default is 10).
         :type k: int
+        :param numthreads: The number of threads to run HiDeF (default is 8).
+        :type numthreads: int
         :raises CellmapsGenerateHierarchyError: If there was an error
         :return: Resulting hierarchy or ``None`` if no hierarchy from HiDeF
         :return: (hierarchy as list,
@@ -662,7 +666,7 @@ class CDAPSHiDeFHierarchyGenerator(HierarchyGenerator):
         (parent_net_path, parent_net, largest_net, edgelist_files) = self._create_edgelist_files_for_networks(networks)
 
         hier, cdaps_out_file = self.get_hierarchy_from_edgelists(outdir, edgelist_files, largest_net,
-                                                                 algorithm, maxres, k)
+                                                                 algorithm, maxres, k, numthreads)
         self._clean_tmp_edgelist_files(edgelist_files)
         self._annotate_hierarchy(network=hier, path=parent_net_path)
         self._annotate_hierarchy_nodes(network=hier)

--- a/cellmaps_generate_hierarchy/runner.py
+++ b/cellmaps_generate_hierarchy/runner.py
@@ -32,6 +32,7 @@ class CellmapsGenerateHierarchy(object):
     K_DEFAULT = 10
     ALGORITHM = 'leiden'
     MAXRES = 80
+    NUMTHREADS = 8
 
     def __init__(self, outdir=None,
                  inputdirs=[],
@@ -39,6 +40,7 @@ class CellmapsGenerateHierarchy(object):
                  algorithm=ALGORITHM,
                  maxres=MAXRES,
                  k=K_DEFAULT,
+                 numthreads=NUMTHREADS,
                  gene_node_attributes=None,
                  hiergen=None,
                  name=None,
@@ -70,6 +72,8 @@ class CellmapsGenerateHierarchy(object):
         :type maxres: int
         :param k: Number of neighbors for graph construction (default: 10)
         :type k: int
+        :param numthreads: The number of threads to run HiDeF (default is 8).
+        :type numthreads: int
         :param gene_node_attributes: TSV file(s) or directory containing additional gene attributes to annotate network nodes
         :type gene_node_attributes: list[str]
         :param hiergen: Hierarchy generator object that clusters and converts networks to hierarchical structure
@@ -121,6 +125,7 @@ class CellmapsGenerateHierarchy(object):
         self._algorithm = algorithm
         self._maxres = maxres
         self._k = k
+        self._numthreads = numthreads
         self._gene_node_attributes = gene_node_attributes
         self._hiergen = hiergen
         self._name = name
@@ -149,6 +154,7 @@ class CellmapsGenerateHierarchy(object):
                                      'algorithm': self._algorithm,
                                      'maxres': self._maxres,
                                      'k': self._k,
+                                     'numthreads': self._numthreads,
                                      'gene_node_attributes': str(self._gene_node_attributes),
                                      'hiergen': str(self._hiergen),
                                      'ndexserver': self._server,
@@ -622,7 +628,7 @@ class CellmapsGenerateHierarchy(object):
 
             # generate hierarchy and get parent ppi
             hierarchy, parent_ppi = self._hiergen.get_hierarchy(ppi_network_prefix_paths, self._algorithm, self._maxres,
-                                                                self._k)
+                                                                self._k, self._numthreads)
 
             if not self.keep_intermediate_files:
                 self._remove_ppi_networks(ppi_network_prefix_paths)


### PR DESCRIPTION
If using default and fixed numthreads=8 in hidef, but in slurm system you ask for 1 or 2 cpu, it is effective using 1 or 2 cpu, but it also create 8 subprocess(?) in the same compute node. Also induce significant memory usage. Exposing parameter for better control.