### PR TITLE
Fix weighted edgelist crash on edges missing Weight attribute + Add tests

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+0.2.6 (TBD)
+-----------
+
+* Added ``--weighted_edgelist`` flag to enable generation of a single weighted edge list with cosine similarity 
+  values as a third column, instead of multiple cutoff-based edge lists. When this flag is set, only the first 
+  cutoff value from ``--ppi_cutoffs`` is used (defaults to parent cutoff if not specified), and the resulting edge list 
+  includes edge weights that can be utilized by HiDeF for hierarchy generation.
+
 0.2.5 (2025-10-08)
 -------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,13 +2,15 @@
 History
 =======
 
-0.2.6 (TBD)
+0.3.0a1
 -----------
 
-* Added ``--weighted_edgelist`` flag to enable generation of a single weighted edge list with cosine similarity 
-  values as a third column, instead of multiple cutoff-based edge lists. When this flag is set, only the first 
-  cutoff value from ``--ppi_cutoffs`` is used (defaults to parent cutoff if not specified), and the resulting edge list 
+* Added ``--weighted_edgelist`` flag to enable generation of a single weighted edge list with cosine similarity
+  values as a third column, instead of multiple cutoff-based edge lists. When this flag is set, only the first
+  cutoff value from ``--ppi_cutoffs`` is used (defaults to parent cutoff if not specified), and the resulting edge list
   includes edge weights that can be utilized by HiDeF for hierarchy generation.
+
+  * Added test suite for verifying weighted edgelist behavior.
 
 0.2.5 (2025-10-08)
 -------------------

--- a/cellmaps_generate_hierarchy/__init__.py
+++ b/cellmaps_generate_hierarchy/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = 'Cell Maps team'
 __email__ = 'tools@cm4ai.org'
-__version__ = '0.2.5'
+__version__ = '0.2.6a1'
 __repo_url__ = 'https://github.com/idekerlab/cellmaps_generate_hierarchy'
 __description__ = 'A tool to generate hierarchies from protein to protein interaction networks'
 __computation_name__ = 'Hierarchy'

--- a/cellmaps_generate_hierarchy/__init__.py
+++ b/cellmaps_generate_hierarchy/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = 'Cell Maps team'
 __email__ = 'tools@cm4ai.org'
-__version__ = '0.2.6a1'
+__version__ = '0.3.0a1'
 __repo_url__ = 'https://github.com/idekerlab/cellmaps_generate_hierarchy'
 __description__ = 'A tool to generate hierarchies from protein to protein interaction networks'
 __computation_name__ = 'Hierarchy'

--- a/cellmaps_generate_hierarchy/hierarchy.py
+++ b/cellmaps_generate_hierarchy/hierarchy.py
@@ -448,13 +448,13 @@ class CDAPSHiDeFHierarchyGenerator(HierarchyGenerator):
             for edge_id, edge_obj in net.get_edges():
                 edge = (edge_obj['s'], edge_obj['t'])
                 weight = None
-                
+
                 # If in weighted mode, extract the edge weight
                 if self._weighted_mode:
                     weight_attr = net.get_edge_attribute(edge_id, constants.WEIGHTED_PPI_EDGELIST_WEIGHT_COL)
-                    if weight_attr:
+                    if isinstance(weight_attr, dict):
                         weight = weight_attr.get('v')
-                
+
                 if len(removed_edges) >= int(len(net.get_edges()) * (self._bootstrap_edges / 100)):
                     remaining_edges.append((edge[0], edge[1], weight))
                 elif edge not in all_removed_edges:
@@ -467,11 +467,11 @@ class CDAPSHiDeFHierarchyGenerator(HierarchyGenerator):
                     s, t = edge_data[0], edge_data[1]
                     line = str(largest_name_to_id[id_to_name[s]]) + '\t' + \
                            str(largest_name_to_id[id_to_name[t]])
-                    
+
                     # Add weight as third column if in weighted mode and weight exists
                     if self._weighted_mode and edge_data[2] is not None:
                         line += '\t' + str(edge_data[2])
-                    
+
                     line += '\n'
                     f.write(line)
 
@@ -482,11 +482,11 @@ class CDAPSHiDeFHierarchyGenerator(HierarchyGenerator):
                         s, t = edge_data[0], edge_data[1]
                         line = str(largest_name_to_id[id_to_name[s]]) + '\t' + \
                                str(largest_name_to_id[id_to_name[t]])
-                        
+
                         # Add weight as third column if in weighted mode and weight exists
                         if self._weighted_mode and edge_data[2] is not None:
                             line += '\t' + str(edge_data[2])
-                        
+
                         line += '\n'
                         f.write(line)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,20 @@
-# Use an official Python runtime as a parent image
-FROM continuumio/miniconda3
-
-RUN apt-get --allow-releaseinfo-change update
-RUN apt-get install -y build-essential 
-
-RUN mkdir /tmp/cellmaps_generate_hierarchy
-COPY ./ /tmp/cellmaps_generate_hierarchy/
-RUN pip install /tmp/cellmaps_generate_hierarchy
-
-RUN rm -rf /tmp/cellmaps_generate_hierarchy
-
-ENTRYPOINT ["/opt/conda/bin/cellmaps_generate_hierarchycmd.py"]
-
+# ---- build stage ----
+FROM python:3.9-slim AS build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    git \
+  && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY . /src
+# build wheels for your package + deps
+RUN pip install --no-cache-dir --upgrade pip wheel \
+ && pip wheel --no-cache-dir --wheel-dir /wheels .
+# ---- runtime stage ----
+FROM python:3.9-slim
+COPY --from=build /wheels /wheels
+RUN pip install --no-cache-dir /wheels/* \
+ && rm -rf /wheels
+# the package exposes a CLI users run as `cellmaps_generate_hierarchycmd.py -h`
+ENTRYPOINT ["cellmaps_generate_hierarchycmd.py"]
 CMD ["--help"]

--- a/docs/extendedusagetutorial.rst
+++ b/docs/extendedusagetutorial.rst
@@ -1,0 +1,105 @@
+==========================
+Extended usage tutorial
+==========================
+
+The :doc:`usage` page covers every command-line flag, but many workflows combine
+those options in specific ways. This tutorial ties the arguments together by
+walking through common hierarchy-generation scenarios, showing what to pass to
+``cellmaps_generate_hierarchycmd.py`` and why.
+
+Standard hierarchy generation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use this flow when you want to generate a hierarchy from one or more embedding
+directories and inspect the results locally.
+
+#. Prepare the required inputs described in :doc:`inputs`.
+#. Pick or create an output directory (it does not need to exist beforehand).
+#. Run:
+
+   .. code-block:: bash
+
+      cellmaps_generate_hierarchycmd.py ./my_output \\
+          --coembedding_dirs ./fold1 ./fold2
+
+The command builds cosine-similarity networks for each cutoff in the default
+``--ppi_cutoffs`` list, runs HiDeF, and writes ``hierarchy.cx2`` plus the parent
+interactome.
+
+Single weighted edgelist workflow
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Certain  tools prefer a single weighted edgelist instead of multiple cutoff-based networks.
+Enable ``--weighted_edgelist`` to collapse the run into a single TSV that
+contains ``node_a node_b weight`` columns:
+
+.. code-block:: bash
+
+   cellmaps_generate_hierarchycmd.py ./weighted_run \\
+       --coembedding_dirs ./fold1 ./fold2 \\
+       --weighted_edgelist \\
+       --ppi_cutoffs 0.05
+
+When ``--weighted_edgelist`` is set, only one cutoff is used (``0.05``above). If more cutoffs are provided, the first one is used. 
+If no cutoffs are provided, the tool falls back to ``--hierarchy_parent_cutoff``.
+
+Bootstrap-driven stability checks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``--bootstrap_edges`` to quantify how sensitive your hierarchy is to noisy
+edges. The argument accepts a percentage from 0 to 99 and randomly removes that
+portion of edges from each cutoff-specific network before running HiDeF.
+
+.. code-block:: bash
+
+   cellmaps_generate_hierarchycmd.py ./bootstrap_run \\
+       --coembedding_dirs ./embeddings \\
+       --bootstrap_edges 10 \\
+       --ppi_cutoffs 0.02 0.05 0.1
+
+Repeat the run a few times and compare the resulting hierarchies to gauge robustness.
+
+Enriching hierarchies with custom attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Merge additional annotations into nodes by supplying one or more RO-Crates or
+TSV files via ``--gene_node_attributes``:
+
+.. code-block:: bash
+
+   cellmaps_generate_hierarchycmd.py ./annotated_run \\
+       --coembedding_dirs ./coembeddings \\
+       --gene_node_attributes ./downloads/ppi_rocrate ./downloads/img_rocrate
+
+Uploading to NDEx
+~~~~~~~~~~~~~~~~~~~~~
+
+After validating a run, push the hierarchy and its parent interactome to NDEx by
+reusing the output directory in ``ndexsave`` mode. Credentials can be provided
+directly or via environment variables; if you pass ``--ndexpassword -`` the
+command prompts interactively.
+
+.. code-block:: bash
+
+   cellmaps_generate_hierarchycmd.py ./my_output \\
+       --mode ndexsave \\
+       --ndexserver idekerlab.ndexbio.org \\
+       --ndexuser <USER> --ndexpassword -
+
+Run this mode only after the hierarchy exists at ``./my_output``; otherwise the
+uploader cannot find ``hierarchy.cx2`` and ``hierarchy_parent.cx2``.
+
+Converting to HiDeF files
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``convert`` mode produces HiDeF ``.nodes`` and ``.edges`` files from a
+previously generated hierarchy. This is useful when feeding the hierarchy into
+tools that expect native HiDeF outputs.
+
+.. code-block:: bash
+
+   cellmaps_generate_hierarchycmd.py ./hidef_files \\
+       --mode convert --hcx_dir ./my_output
+
+If ``--hcx_dir`` is omitted, the converter expects ``hierarchy.cx2`` inside the
+``outdir``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,7 @@ Overview of Cell Maps Generate Hierarchy
 
    installation
    usage
+   extendedusagetutorial
    inputs
    outputs
    modules

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -84,6 +84,9 @@ In `convert` mode (converting hierarchy to HiDeF files)
 
 *Optional*
 
+- ``--provenance PROVENANCE``
+    Path to JSON provenance describing the input files. Required when a provided directory is missing ``ro-crate-metadata.json``.
+    
 - ``--ndexserver NDEXSERVER``
     Server where the hierarchy can be converted to HCX and saved. Default is ``idekerlab.ndexbio.org``.
 
@@ -120,11 +123,29 @@ In `convert` mode (converting hierarchy to HiDeF files)
 - ``--ppi_cutoffs PPI_CUTOFFS [PPI_CUTOFFS ...]``
     Cutoffs used to generate PPI input networks. Default cutoffs are provided in the code.
 
+- ``--hierarchy_parent_cutoff HIERARCHY_PARENT_CUTOFF``
+    PPI cutoff used to select the parent network that seeds hierarchy creation.
+
+- ``--weighted_edgelist``
+    If set, only the first ``--ppi_cutoffs`` value (or the hierarchy parent cutoff) is used and a single cosine-similarity weighted edgelist.tsv file is produced instead of per-cutoff edge lists.
+
+- ``--bootstrap_edges BOOTSTRAP_EDGES``
+    Percentage (0-99) of edges randomly removed from each PPI network to perform bootstrap sampling before hierarchy generation.
+
 - ``--skip_layout``
     If set, skips the layout of hierarchy step.
 
 - ``--visibility``
     If set, the Hierarchy and interactome network loaded onto NDEx will be publicly visible.
+
+- ``--keep_intermediate_files``
+    If set, intermediate CX/CX2 PPI files are kept on disk.
+
+- ``--gene_node_attributes PATH [PATH ...]``
+    Additional RO-Crates or TSVs providing per-gene attributes to merge into the hierarchy.
+
+- ``--skip_logging``
+    If set, ``output.log`` and ``error.log`` files will not be created in the run directory.
 
 - ``--logconf LOGCONF``
     Path to python logging configuration file. Setting this overrides ``-v`` parameter which uses the default logger.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -227,6 +227,8 @@ Programmatically:
 Convert hierarchy to HiDeF
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+To convert hierarchy to HiDeF .nodes and .edges files, use the following command:
+
 .. code-block::
 
     cellmaps_generate_hierarchycmd.py ./output_dir --mode convert --hcx_dir ./examples/

--- a/tests/test_weighted_edgelist.py
+++ b/tests/test_weighted_edgelist.py
@@ -121,29 +121,38 @@ class TestWeightedEdgelist(unittest.TestCase):
         self.assertTrue(os.path.isfile(removed_path))
         with open(removed_path) as f:
             removed = f.read()
-        # the removed edge line should have 3 tab-separated fields
-        self.assertEqual(1, len(removed.strip().splitlines()))
-        self.assertEqual(3, len(removed.strip().split('\t')))
-        self.assertIn('0.9', removed)
+        # deterministic: only the (0, 1) edge was removed, weight 0.9
+        self.assertEqual('0\t1\t0.9\n', removed)
+        # and the surviving edge still lands in the main edgelist, weighted
+        self.assertEqual('1\t2\t0.5\n', self._read_edgelist(prefix))
 
     def test_weighted_mode_missing_weight_falls_back_to_two_columns(self):
         """weighted_mode=True but an edge has no Weight attribute.
 
-        The writer already guards each line with ``edge_data[2] is not None``,
-        so the documented intent is a graceful fall back to a 2-column line for
-        that edge. This test pins that intent.
-
-        NOTE: this currently FAILS on the dev branch. ``get_edge_attribute``
-        returns the tuple ``(None, None)`` (not ``None``) for a missing
-        attribute, which is truthy, so ``if weight_attr:`` passes and
-        ``weight_attr.get('v')`` raises AttributeError. Fix in hierarchy.py,
-        e.g. ``if isinstance(weight_attr, dict):`` before calling .get('v').
+        The writer guards each line with ``edge_data[2] is not None``, so an
+        edge without a weight must fall back to a plain 2-column line rather
+        than crashing. Regression guard for the ``get_edge_attribute`` returning
+        the truthy tuple ``(None, None)`` bug.
         """
         prefix = self._write_network('wnet',
                                      [('n1', 'n2', 0.9), ('n2', 'n5', None)])
         gen = self._make_generator(weighted_mode=True)
         gen._create_edgelist_files_for_networks([prefix])
         self.assertEqual('0\t1\t0.9\n1\t2\n', self._read_edgelist(prefix))
+
+    def test_weighted_mode_across_multiple_networks(self):
+        """Weights are written correctly for every network in the list,
+        including the largest (reused in place) and the smaller ones
+        (reloaded from disk). Node ids in every edgelist are remapped through
+        the largest network's name->id table."""
+        small = self._write_network('small', [('n1', 'n2', 0.9)])
+        # 'large' has an extra node + edge so it is the largest by file size
+        large = self._write_network('large',
+                                    [('n1', 'n2', 0.3), ('n2', 'n5', 0.7)])
+        gen = self._make_generator(weighted_mode=True)
+        gen._create_edgelist_files_for_networks([small, large])
+        self.assertEqual('0\t1\t0.9\n', self._read_edgelist(small))
+        self.assertEqual('0\t1\t0.3\n1\t2\t0.7\n', self._read_edgelist(large))
 
 
 class TestWeightedEdgelistCmd(unittest.TestCase):

--- a/tests/test_weighted_edgelist.py
+++ b/tests/test_weighted_edgelist.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for the --weighted_edgelist / weighted_mode feature."""
+
+import os
+import json
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+import ndex2
+from cellmaps_utils import constants
+
+from cellmaps_generate_hierarchy import cellmaps_generate_hierarchycmd
+from cellmaps_generate_hierarchy.hcx import HCXFromCDAPSCXHierarchy
+from cellmaps_generate_hierarchy.hierarchy import CDAPSHiDeFHierarchyGenerator
+
+WEIGHT_COL = constants.WEIGHTED_PPI_EDGELIST_WEIGHT_COL
+
+
+class TestWeightedEdgelist(unittest.TestCase):
+    """Tests for weighted edge list generation."""
+
+    def setUp(self):
+        self._temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self._temp_dir, ignore_errors=True)
+
+    # ------------------------------------------------------------------ #
+    # helpers
+    # ------------------------------------------------------------------ #
+    def _write_network(self, name, edges):
+        """Builds a NiceCXNetwork with the given edges and writes it to a
+        CX file, returning its prefix path (no suffix).
+
+        :param edges: iterable of (src_name, tgt_name, weight_or_None)
+        """
+        net = ndex2.nice_cx_network.NiceCXNetwork()
+        net.set_name(name)
+        node_ids = {}
+        for src, tgt, weight in edges:
+            for gene in (src, tgt):
+                if gene not in node_ids:
+                    node_ids[gene] = net.create_node(gene)
+            edge_id = net.create_edge(edge_source=node_ids[src],
+                                      edge_target=node_ids[tgt])
+            if weight is not None:
+                net.set_edge_attribute(edge_id, WEIGHT_COL, weight)
+        prefix = os.path.join(self._temp_dir, name)
+        with open(prefix + constants.CX_SUFFIX, 'w') as f:
+            json.dump(net.to_cx(), f)
+        return prefix
+
+    def _make_generator(self, **kwargs):
+        mockprov = MagicMock()
+        mockprov.register_dataset = MagicMock(
+            side_effect=['id0', 'id1', 'id2', 'id3'])
+        mockprov.get_default_date_format_str = MagicMock(
+            return_value='%Y-%m-%d')
+        return CDAPSHiDeFHierarchyGenerator(
+            provenance_utils=mockprov,
+            author='author',
+            version='version',
+            hcxconverter=HCXFromCDAPSCXHierarchy(),
+            **kwargs)
+
+    def _read_edgelist(self, prefix):
+        with open(prefix + CDAPSHiDeFHierarchyGenerator.EDGELIST_TSV) as f:
+            return f.read()
+
+    # ------------------------------------------------------------------ #
+    # constructor / flag storage
+    # ------------------------------------------------------------------ #
+    def test_weighted_mode_defaults_to_false(self):
+        gen = self._make_generator()
+        self.assertFalse(gen._weighted_mode)
+
+    def test_weighted_mode_can_be_enabled(self):
+        gen = self._make_generator(weighted_mode=True)
+        self.assertTrue(gen._weighted_mode)
+
+    # ------------------------------------------------------------------ #
+    # edgelist output
+    # ------------------------------------------------------------------ #
+    def test_weighted_mode_writes_third_weight_column(self):
+        """weighted_mode=True with weights present -> 3-column output."""
+        prefix = self._write_network('wnet',
+                                     [('n1', 'n2', 0.9), ('n2', 'n5', 0.5)])
+        gen = self._make_generator(weighted_mode=True)
+        gen._create_edgelist_files_for_networks([prefix])
+        self.assertEqual('0\t1\t0.9\n1\t2\t0.5\n', self._read_edgelist(prefix))
+
+    def test_default_mode_ignores_weights(self):
+        """weighted_mode=False (default) -> 2 columns even when the edges
+        carry Weight attributes. Guards against the feature leaking into the
+        normal cutoff-based path."""
+        prefix = self._write_network('wnet',
+                                     [('n1', 'n2', 0.9), ('n2', 'n5', 0.5)])
+        gen = self._make_generator()
+        gen._create_edgelist_files_for_networks([prefix])
+        self.assertEqual('0\t1\n1\t2\n', self._read_edgelist(prefix))
+
+    def test_removed_edges_file_includes_weight_column(self):
+        """The bootstrap-removed edges file must also carry the weight column
+        in weighted mode. random.sample is patched so exactly the first edge
+        is flagged for removal, deterministically."""
+        prefix = self._write_network('wnet',
+                                     [('n1', 'n2', 0.9), ('n2', 'n5', 0.5)])
+        gen = self._make_generator(weighted_mode=True)
+        gen._bootstrap_edges = 50  # threshold int(2 * 0.5) == 1 -> one removed
+
+        # force the (0, 1) edge to be the one sampled for removal
+        with patch('cellmaps_generate_hierarchy.hierarchy.random.sample',
+                   return_value=[(0, 1)]):
+            gen._create_edgelist_files_for_networks([prefix])
+
+        removed_path = prefix + '_removed_edges.tsv'
+        self.assertTrue(os.path.isfile(removed_path))
+        with open(removed_path) as f:
+            removed = f.read()
+        # the removed edge line should have 3 tab-separated fields
+        self.assertEqual(1, len(removed.strip().splitlines()))
+        self.assertEqual(3, len(removed.strip().split('\t')))
+        self.assertIn('0.9', removed)
+
+    def test_weighted_mode_missing_weight_falls_back_to_two_columns(self):
+        """weighted_mode=True but an edge has no Weight attribute.
+
+        The writer already guards each line with ``edge_data[2] is not None``,
+        so the documented intent is a graceful fall back to a 2-column line for
+        that edge. This test pins that intent.
+
+        NOTE: this currently FAILS on the dev branch. ``get_edge_attribute``
+        returns the tuple ``(None, None)`` (not ``None``) for a missing
+        attribute, which is truthy, so ``if weight_attr:`` passes and
+        ``weight_attr.get('v')`` raises AttributeError. Fix in hierarchy.py,
+        e.g. ``if isinstance(weight_attr, dict):`` before calling .get('v').
+        """
+        prefix = self._write_network('wnet',
+                                     [('n1', 'n2', 0.9), ('n2', 'n5', None)])
+        gen = self._make_generator(weighted_mode=True)
+        gen._create_edgelist_files_for_networks([prefix])
+        self.assertEqual('0\t1\t0.9\n1\t2\n', self._read_edgelist(prefix))
+
+
+class TestWeightedEdgelistCmd(unittest.TestCase):
+    """Tests for the --weighted_edgelist argument and its wiring in main()."""
+
+    def test_weighted_edgelist_flag_defaults_false(self):
+        res = cellmaps_generate_hierarchycmd._parse_arguments(
+            'desc', ['outdir', '--coembedding_dirs', 'foo'])
+        self.assertFalse(res.weighted_edgelist)
+
+    def test_weighted_edgelist_flag_sets_true(self):
+        res = cellmaps_generate_hierarchycmd._parse_arguments(
+            'desc', ['outdir', '--coembedding_dirs', 'foo',
+                     '--weighted_edgelist'])
+        self.assertTrue(res.weighted_edgelist)
+
+    @patch('cellmaps_generate_hierarchy.cellmaps_generate_hierarchycmd.'
+           'CellmapsGenerateHierarchy')
+    @patch('cellmaps_generate_hierarchy.cellmaps_generate_hierarchycmd.'
+           'CDAPSHiDeFHierarchyGenerator')
+    @patch('cellmaps_generate_hierarchy.cellmaps_generate_hierarchycmd.'
+           'CosineSimilarityPPIGenerator')
+    def test_main_collapses_cutoffs_and_passes_weighted_mode(
+            self, mock_ppigen, mock_hiergen, mock_runner):
+        """With --weighted_edgelist, main() must collapse ppi_cutoffs to a
+        single (first) cutoff and pass weighted_mode=True to the hierarchy
+        generator."""
+        mock_hiergen.HIERARCHY_PARENT_CUTOFF = 0.1
+        mock_runner.return_value.run.return_value = 0
+        temp_dir = tempfile.mkdtemp()
+        try:
+            rc = cellmaps_generate_hierarchycmd.main(
+                ['prog', temp_dir,
+                 '--coembedding_dirs', 'foo',
+                 '--ppi_cutoffs', '0.001', '0.05', '0.1',
+                 '--weighted_edgelist'])
+            self.assertEqual(0, rc)
+
+            # cutoffs collapsed to just the first one
+            _, ppi_kwargs = mock_ppigen.call_args
+            self.assertEqual([0.001], ppi_kwargs['cutoffs'])
+
+            # weighted_mode threaded through to the generator
+            _, hier_kwargs = mock_hiergen.call_args
+            self.assertTrue(hier_kwargs['weighted_mode'])
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    @patch('cellmaps_generate_hierarchy.cellmaps_generate_hierarchycmd.'
+           'CellmapsGenerateHierarchy')
+    @patch('cellmaps_generate_hierarchy.cellmaps_generate_hierarchycmd.'
+           'CDAPSHiDeFHierarchyGenerator')
+    @patch('cellmaps_generate_hierarchy.cellmaps_generate_hierarchycmd.'
+           'CosineSimilarityPPIGenerator')
+    def test_main_without_flag_keeps_all_cutoffs(
+            self, mock_ppigen, mock_hiergen, mock_runner):
+        """Without the flag, all cutoffs are preserved and weighted_mode is
+        False."""
+        mock_runner.return_value.run.return_value = 0
+        temp_dir = tempfile.mkdtemp()
+        try:
+            cellmaps_generate_hierarchycmd.main(
+                ['prog', temp_dir,
+                 '--coembedding_dirs', 'foo',
+                 '--ppi_cutoffs', '0.001', '0.05', '0.1'])
+            _, ppi_kwargs = mock_ppigen.call_args
+            self.assertEqual([0.001, 0.05, 0.1], ppi_kwargs['cutoffs'])
+            _, hier_kwargs = mock_hiergen.call_args
+            self.assertFalse(hier_kwargs['weighted_mode'])
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
In weighted mode, `get_edge_attribute` returns the tuple `(None, None)` for a
missing attribute rather than `None`. Since a non-empty tuple is passes this guard, the
`if weight_attr:` guard passed and `.get('v')` raised `AttributeError`, crashing
edgelist generation for any network with an edge lacking a `Weight` attribute.

Fixed by guarding on `isinstance(weight_attr, dict)`, which lets the writer fall
back to a 2-column line as the surrounding code already intended.

## Tests
Added `tests/test_weighted_edgelist.py` (11 tests):
- 3-column weighted output and the default unweighted path (regression guard)
- missing-weight fallback to 2 columns
- weights across multiple networks and in the bootstrap removed-edges file
- `--weighted_edgelist` CLI flag and its wiring in `main()` (cutoff collapse + `weighted_mode` passthrough)

Full existing suite passes (63) with the fix in place.

## Note
A weighted network with a mix of weighted and unweighted edges now produces an
edgelist with mixed 2-/3-column lines. This matches the original writer's intent
and only surfaced because the crash was hiding it. In practice weights come from
`ppi.py`, which sets `Weight` on every edge, so mixed files shouldn't occur — but
worth a look if HiDeF's weighted parsing is strict about column counts.